### PR TITLE
feat: remove frame-blocking headers for pull requests

### DIFF
--- a/dev/_headers
+++ b/dev/_headers
@@ -1,0 +1,8 @@
+## these security headers are created by gatsby-plugin-netlify
+## we need to remove the X-Frame-Options: DENY to allow Pastel to work
+
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: same-origin

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "rm -f build/index.html && mkdir -p build && cp dev/index.html build/index.html && netlify-build",
+    "build": "rm -rf build && mkdir -p build && cp -a dev/ build && netlify-build",
     "test": "npm run lint && npm run ava",
     "lint": "npm run eslint && npm run prettier",
     "eslint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{src,init}/**/*.js\"",

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const glob = require('glob');
 const { injectScript } = require('./inject-script');
 
@@ -16,6 +17,12 @@ module.exports = {
 
     // ...but wait for them all to finish before moving on
     await Promise.all(promises);
+
+    // make sure frames are allowed so Pastel can do its thang
+    const [headersFile] = glob.sync(`${BUILD_DIR}/_headers`);
+    const headers = fs.readFileSync(headersFile, 'utf8');
+    const cleaned = headers.replace(/^\s*x-frame-options:.*$/gim, '');
+    fs.writeFileSync(headersFile, cleaned, { encoding: 'utf8' });
 
     // TODO how do we log this in a better way?
     console.log(


### PR DESCRIPTION
Pastel uses frames to enable comment overlays. For security on production sites, adding the `X-Frame-Options: DENY` header is a good idea, but this breaks Pastel.

To work around this, this change will look for a `_headers` file and remove the `X-Frame-Options` header on deploy previews _only_ (there is no effect on production sites) so that Pastel can be used.